### PR TITLE
Feature/arc 260 badge component

### DIFF
--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -1,7 +1,7 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 import React from 'react';
 
-import { Badge } from './Badge';
+import Badge from './Badge';
 
 export default {
 	title: 'Components/Badge',

--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -1,0 +1,28 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import React from 'react';
+
+import { Badge } from './Badge';
+
+export default {
+	title: 'Components/Badge',
+	component: Badge,
+} as ComponentMeta<typeof Badge>;
+
+const Template: ComponentStory<typeof Badge> = (args) => <Badge {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+	text: 'Pending approval',
+};
+
+export const Success = Template.bind({});
+Success.args = {
+	text: 'Approval granted',
+	type: 'success',
+};
+
+export const Error = Template.bind({});
+Error.args = {
+	text: 'Approval denied',
+	type: 'error',
+};

--- a/src/components/Badge/Badge.test.tsx
+++ b/src/components/Badge/Badge.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { Badge } from './Badge';
+
+const renderBadge = ({ text = 'text', ...rest }) => {
+	return render(<Badge text={text} {...rest} />);
+};
+
+describe('<Badge />', () => {
+	it('Should be able to render', () => {
+		const text = 'badge-label';
+		const { getByText } = renderBadge({ text });
+
+		const badge = getByText(text);
+
+		expect(badge).toBeInTheDocument();
+	});
+
+	it('Should render the text correctly', () => {
+		const text = 'this is a badge';
+		const { container } = renderBadge({ text });
+
+		const badge = container.firstChild;
+
+		expect(badge?.textContent).toEqual(text);
+	});
+
+	it('Should set the correct className', () => {
+		const text = 'badge-label';
+		const className = 'c-badge-custom';
+		const variants = ['success', 'error'];
+		const { getByText } = renderBadge({ text, className, variants });
+
+		const badge = getByText(text);
+
+		expect(badge).toHaveClass('c-badge');
+		expect(badge).toHaveClass(className);
+		expect(badge).toHaveClass(`c-badge--${variants[0]}`);
+		expect(badge).toHaveClass(`c-badge--${variants[1]}`);
+	});
+
+	it('Should set the correct className for every type', () => {
+		const defaultText = 'default';
+		const successText = 'success';
+		const errorText = 'error';
+
+		renderBadge({ text: defaultText });
+		renderBadge({ text: successText, type: 'success' });
+		renderBadge({ text: errorText, type: 'error' });
+
+		const defaultBadge = screen.getByText(defaultText);
+		const successBadge = screen.getByText(successText);
+		const errorBadge = screen.getByText(errorText);
+
+		expect(defaultBadge).toHaveClass('c-badge--default');
+		expect(successBadge).toHaveClass('c-badge--success');
+		expect(errorBadge).toHaveClass('c-badge--error');
+	});
+});

--- a/src/components/Badge/Badge.test.tsx
+++ b/src/components/Badge/Badge.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 
-import { Badge } from './Badge';
+import Badge from './Badge';
 
 const renderBadge = ({ text = 'text', ...rest }) => {
 	return render(<Badge text={text} {...rest} />);

--- a/src/components/Badge/Badge.test.tsx
+++ b/src/components/Badge/Badge.test.tsx
@@ -2,8 +2,9 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 
 import Badge from './Badge';
+import { BadgeProps } from './Badge.types';
 
-const renderBadge = ({ text = 'text', ...rest }) => {
+const renderBadge = ({ text = 'text', ...rest }: BadgeProps) => {
 	return render(<Badge text={text} {...rest} />);
 };
 
@@ -24,6 +25,18 @@ describe('<Badge />', () => {
 		const badge = container.firstChild;
 
 		expect(badge?.textContent).toEqual(text);
+	});
+
+	it('Should render a react node correctly', () => {
+		const mockLabel = 'label';
+		const mockClass = 'class';
+		const text = <span className={mockClass}>{mockLabel}</span>;
+		const { getByText } = renderBadge({ text });
+
+		const component = getByText(mockLabel);
+
+		expect(component).toBeInTheDocument;
+		expect(component).toHaveClass(mockClass);
 	});
 
 	it('Should set the correct className', () => {

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -5,7 +5,7 @@ import { getVariantClasses } from '../../utils';
 
 import { BadgeProps } from './Badge.types';
 
-export const Badge: FunctionComponent<BadgeProps> = ({
+const Badge: FunctionComponent<BadgeProps> = ({
 	className,
 	text,
 	type = 'default',
@@ -18,3 +18,5 @@ export const Badge: FunctionComponent<BadgeProps> = ({
 
 	return <div className={rootCls}>{text}</div>;
 };
+
+export default Badge;

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -1,5 +1,7 @@
-import classnames from 'classnames';
+import clsx from 'clsx';
 import React, { FunctionComponent } from 'react';
+
+import { getVariantClasses } from '../../utils';
 
 import { BadgeProps } from './Badge.types';
 
@@ -9,6 +11,10 @@ export const Badge: FunctionComponent<BadgeProps> = ({
 	type = 'default',
 	rootClassName: root = 'c-badge',
 	variants,
-}) => (
-	<div className={classnames(className, 'c-badge', { [`c-badge--${type}`]: type })}>{text}</div>
-);
+}) => {
+	const rootCls = clsx(className, root, getVariantClasses(root, variants), {
+		[`c-badge--${type}`]: type,
+	});
+
+	return <div className={rootCls}>{text}</div>;
+};

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -1,11 +1,11 @@
 import clsx from 'clsx';
-import React, { FunctionComponent } from 'react';
+import React, { FC } from 'react';
 
 import { getVariantClasses } from '../../utils';
 
 import { BadgeProps } from './Badge.types';
 
-const Badge: FunctionComponent<BadgeProps> = ({
+const Badge: FC<BadgeProps> = ({
 	className,
 	text,
 	type = 'default',

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -1,0 +1,14 @@
+import classnames from 'classnames';
+import React, { FunctionComponent } from 'react';
+
+import { BadgeProps } from './Badge.types';
+
+export const Badge: FunctionComponent<BadgeProps> = ({
+	className,
+	text,
+	type = 'default',
+	rootClassName: root = 'c-badge',
+	variants,
+}) => (
+	<div className={classnames(className, 'c-badge', { [`c-badge--${type}`]: type })}>{text}</div>
+);

--- a/src/components/Badge/Badge.types.ts
+++ b/src/components/Badge/Badge.types.ts
@@ -1,0 +1,6 @@
+import { DefaultComponentProps } from '../../types';
+
+export interface BadgeProps extends DefaultComponentProps {
+	text: string;
+	type?: 'default' | 'success' | 'error';
+}

--- a/src/components/Badge/Badge.types.ts
+++ b/src/components/Badge/Badge.types.ts
@@ -1,6 +1,8 @@
+import { ReactNode } from 'react';
+
 import { DefaultComponentProps } from '../../types';
 
 export interface BadgeProps extends DefaultComponentProps {
-	text: string;
+	text: string | ReactNode;
 	type?: 'default' | 'success' | 'error';
 }

--- a/src/components/Badge/index.ts
+++ b/src/components/Badge/index.ts
@@ -1,0 +1,2 @@
+export { default as Badge } from './Badge';
+export * from './Badge.types';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
+export * from './Badge';
 export * from './Box';
 export * from './Button';
 export * from './Checkbox';


### PR DESCRIPTION
[ARC-260](https://meemoo.atlassian.net/jira/software/c/projects/ARC/boards/36?modal=detail&selectedIssue=ARC-260)
[hetarchief-client pr](https://github.com/viaacode/hetarchief-client/pull/38)

# Badge component
* `text` type kan nu ook een `ReactNode` renderen

![image](https://user-images.githubusercontent.com/85545258/148385629-a8442736-7109-4794-8591-0781cc2f3ee7.png)
![image](https://user-images.githubusercontent.com/85545258/148385634-a1a7f20a-3c7a-45d1-9c3c-1015d1a01048.png)
![image](https://user-images.githubusercontent.com/85545258/148385636-38c0309d-3d56-498d-8e8b-cab384953480.png)
![image](https://user-images.githubusercontent.com/85545258/148385639-9bd15912-041e-4f19-864c-0f23c63b5fb1.png)
![image](https://user-images.githubusercontent.com/85545258/148385641-c9480fb1-b902-4d4c-82a9-da150847c863.png)
