### PR TITLE
feat(menu): add root class to menu items

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -21,21 +21,20 @@ const Menu: FunctionComponent<MenuProps> = ({
 	variants,
 }) => {
 	const bem = bemCls.bind(root);
-	const rootCls = clsx(className, root, getVariantClasses(root, variants), {
+	const rootCls = clsx(className, root, getVariantClasses(root, variants), 'c-menu--default', {
 		[bem('', 'search-result')]: search,
+		'c-menu--visible--default': isOpen,
 	});
 
 	return (
-		<div
-			className={clsx(rootCls, 'c-menu--default', { 'c-menu--visible--default': isOpen })}
-			style={style}
-		>
+		<div className={rootCls} style={style}>
 			{children || (
 				<MenuContent
 					menuItems={menuItems}
 					onClick={onClick}
 					renderItem={renderItem}
 					noResultsLabel={noResultsLabel}
+					rootClassName={root}
 				/>
 			)}
 		</div>

--- a/src/components/Menu/MenuContent/MenuContent.tsx
+++ b/src/components/Menu/MenuContent/MenuContent.tsx
@@ -14,8 +14,6 @@ const MenuContent: FC<MenuContentProps> = ({
 	rootClassName: root = 'c-menu',
 	variants,
 }) => {
-	console.log('content', root);
-
 	const bem = bemCls.bind(root);
 	const rootCls = clsx(className, bem('item'), getVariantClasses(root, variants));
 

--- a/src/components/Menu/MenuContent/MenuContent.tsx
+++ b/src/components/Menu/MenuContent/MenuContent.tsx
@@ -1,6 +1,8 @@
 import clsx from 'clsx';
 import React, { FC, Fragment, ReactNode } from 'react';
 
+import { bemCls, getVariantClasses } from '../../../utils';
+
 import { MenuContentProps, MenuItemInfo } from './MenuContent.types';
 
 const MenuContent: FC<MenuContentProps> = ({
@@ -9,7 +11,14 @@ const MenuContent: FC<MenuContentProps> = ({
 	renderItem,
 	noResultsLabel,
 	onClick = () => null,
+	rootClassName: root = 'c-menu',
+	variants,
 }) => {
+	console.log('content', root);
+
+	const bem = bemCls.bind(root);
+	const rootCls = clsx(className, bem('item'), getVariantClasses(root, variants));
+
 	const renderIcon = (iconNode: ReactNode | string) => <span>{iconNode}</span>;
 
 	const renderMenuItem = (menuItemInfo: MenuItemInfo) => {
@@ -18,14 +27,14 @@ const MenuContent: FC<MenuContentProps> = ({
 		}
 		return (
 			<div
-				className={clsx(className, 'c-menu__item')}
+				className={rootCls}
 				onClick={() => onClick(menuItemInfo.id)}
 				onKeyPress={(e) => (e.key === 'Space' ? onClick(menuItemInfo.id) : () => null)}
 				role="menuitem"
 				tabIndex={0}
 				key={`menu-item-${menuItemInfo.id}`}
 			>
-				<div className="c-menu__label">
+				<div className={bem('label')}>
 					{menuItemInfo.icon && renderIcon(menuItemInfo.icon)}
 					{menuItemInfo.label}
 				</div>
@@ -52,7 +61,7 @@ const MenuContent: FC<MenuContentProps> = ({
 											.join('-')}`}
 									>
 										{renderMenuItems(menuItems)}
-										<div className="c-menu__divider" />
+										<div className={bem('divider')} />
 									</Fragment>
 								);
 							}
@@ -78,8 +87,8 @@ const MenuContent: FC<MenuContentProps> = ({
 		}
 		if (noResultsLabel) {
 			return (
-				<div className="c-menu__item" key={`menu-item-no-results`}>
-					<div className="c-menu__label">{noResultsLabel}</div>
+				<div className={bem('item')} key={`menu-item-no-results`}>
+					<div className={bem('label')}>{noResultsLabel}</div>
 				</div>
 			);
 		}

--- a/src/components/Menu/MenuSearchResultContent/MenuSearchResultContent.tsx
+++ b/src/components/Menu/MenuSearchResultContent/MenuSearchResultContent.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import React, { FC } from 'react';
 
-import { getVariantClasses } from '../../../utils';
+import { bemCls, getVariantClasses } from '../../../utils';
 import { MenuContent } from '../MenuContent';
 
 import {
@@ -14,10 +14,11 @@ const MenuSearchResultContent: FC<MenuSearchResultContentProps> = ({
 	menuItems,
 	noResultsLabel,
 	onClick = () => null,
-	rootClassName: root = 'c-menu__item',
+	rootClassName: root = 'c-menu',
 	variants,
 }) => {
-	const rootCls = clsx(className, root, getVariantClasses(root, variants), {});
+	const bem = bemCls.bind(root);
+	const rootCls = clsx(className, bem('item'), getVariantClasses(root, variants), {});
 
 	const renderMenuItem = (menuItemInfo: MenuSearchResultItemInfo) => {
 		return (
@@ -29,7 +30,7 @@ const MenuSearchResultContent: FC<MenuSearchResultContentProps> = ({
 				tabIndex={0}
 				key={`menu-search-item-${menuItemInfo.id}`}
 			>
-				<div className="c-menu__label">
+				<div className={bem('label')}>
 					<div className={`c-content-type c-content-type--${menuItemInfo.type}`}>
 						{menuItemInfo.icon}
 						{menuItemInfo.label}
@@ -48,6 +49,7 @@ const MenuSearchResultContent: FC<MenuSearchResultContentProps> = ({
 			onClick={onClick}
 			renderItem={renderMenuItem as any}
 			noResultsLabel={noResultsLabel}
+			rootClassName={root}
 		/>
 	);
 };


### PR DESCRIPTION
Root class toegevoegd aan menu items zodat de naamgeving van de styling duidelijker is in https://github.com/viaacode/hetarchief-client/pull/29