### PR TITLE
fix(arc-442): use correct value to identify keypress

### DIFF
--- a/src/components/Menu/MenuContent/MenuContent.tsx
+++ b/src/components/Menu/MenuContent/MenuContent.tsx
@@ -25,7 +25,7 @@ const MenuContent: FC<MenuContentProps> = ({
 			<div
 				className={rootCls}
 				onClick={() => onClick(menuItemInfo.id)}
-				onKeyPress={(e) => (e.key === 'Space' ? onClick(menuItemInfo.id) : () => null)}
+				onKeyPress={(e) => (e.key === ' ' ? onClick(menuItemInfo.id) : () => null)}
 				role="menuitem"
 				tabIndex={0}
 				key={`menu-item-${menuItemInfo.id ?? index}`}


### PR DESCRIPTION
fixed issue where keypress was not correctly registered causing dropdown items to be inaccessible with the keyboard.

https://github.com/viaacode/hetarchief-client/pull/113#discussion_r804563086