### PR TITLE
fix(table): type hinting for Table options prop

### DIFF
--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -1,9 +1,11 @@
 import { action } from '@storybook/addon-actions';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 import React from 'react';
+import { Column } from 'react-table';
 
 import Table from './Table';
 import { defaultSortingIcons } from './Table.const';
+import { TableData } from './Table.types';
 import { mockColumns, mockData } from './__mocks__/table';
 
 export default {
@@ -16,7 +18,8 @@ const Template: ComponentStory<typeof Table> = (args) => <Table {...args} />;
 export const Default = Template.bind({});
 Default.args = {
 	options: {
-		columns: mockColumns,
+		// .bind() doesn't play well with generics so we have to cast our value
+		columns: mockColumns as Column<TableData>[],
 		data: mockData,
 	},
 	sortingIcons: {

--- a/src/components/Table/Table.test.tsx
+++ b/src/components/Table/Table.test.tsx
@@ -1,13 +1,13 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import React, { PropsWithChildren } from 'react';
+import React from 'react';
 
 import Table from './Table';
 import { defaultSortingIcons } from './Table.const';
-import { TableProps } from './Table.types';
+import { TableData, TableProps } from './Table.types';
 import { mockColumns, mockData } from './__mocks__/table';
 
-const renderTable = ({ ...rest }: PropsWithChildren<TableProps<object>>) => {
-	return render(<Table {...rest} />);
+const renderTable = <T extends TableData>(props: TableProps<T>) => {
+	return render(<Table {...props} />);
 };
 
 describe('<Table />', () => {

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,13 +1,13 @@
 import clsx from 'clsx';
-import React, { FC, useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { HeaderGroup, usePagination, useSortBy, useTable } from 'react-table';
 
 import { bemCls, getVariantClasses } from '../../utils';
 
 import { defaultSortingIcons } from './Table.const';
-import { TableProps } from './Table.types';
+import { TableData, TableProps } from './Table.types';
 
-const Table: FC<TableProps<object>> = ({
+const Table = <D extends TableData>({
 	className,
 	onRowClick,
 	onSortChange,
@@ -17,7 +17,7 @@ const Table: FC<TableProps<object>> = ({
 	sortingIcons = defaultSortingIcons,
 	style,
 	variants,
-}) => {
+}: TableProps<D>) => {
 	const bem = bemCls.bind(root);
 	const rootCls = clsx(className, root, getVariantClasses(root, variants));
 
@@ -51,7 +51,7 @@ const Table: FC<TableProps<object>> = ({
 
 	// Render
 
-	const renderSortingIndicator = (column: HeaderGroup) => {
+	const renderSortingIndicator = (column: HeaderGroup<D>) => {
 		if (!column.canSort || column.disableSortBy) return null;
 
 		if (column.isSorted) {

--- a/src/components/Table/Table.types.ts
+++ b/src/components/Table/Table.types.ts
@@ -1,15 +1,26 @@
 import { MouseEvent, ReactNode } from 'react';
-import { SortingRule, TableOptions, UsePaginationInstanceProps } from 'react-table';
+import { Row, SortingRule, TableOptions, UsePaginationInstanceProps } from 'react-table';
 
 import { DefaultComponentProps } from '../../types';
 
-export interface TableProps<T extends object> extends DefaultComponentProps {
-	onRowClick?: (event: MouseEvent<HTMLTableRowElement>, row: T) => void;
+export type {
+	Column,
+	CellProps,
+	Row,
+	SortingRule,
+	TableOptions,
+	UsePaginationInstanceProps,
+} from 'react-table';
+
+export interface TableProps<T extends TableData> extends DefaultComponentProps {
+	onRowClick?: (event: MouseEvent<HTMLTableRowElement>, row: Row<T>) => void;
 	onSortChange?: (rules: SortingRule<T>[]) => void;
 	options: TableOptions<T>;
 	pagination?: (instance: UsePaginationInstanceProps<T>) => ReactNode;
 	sortingIcons?: TableSortingIcons;
 }
+
+export type TableData = Record<string, any>;
 
 export interface TableSortingIcons {
 	asc?: ReactNode;

--- a/src/components/Table/__mocks__/table.tsx
+++ b/src/components/Table/__mocks__/table.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
-import { Column } from 'react-table';
+import { CellProps, Column } from 'react-table';
 
-export const mockData = [1, 2, 3, 4, 5, 6].map((data) => {
+export interface MockTableData {
+	id: number;
+	name: string;
+	created_at: number;
+	child: { id: number };
+}
+
+export const mockData: MockTableData[] = [1, 2, 3, 4, 5, 6].map((data) => {
 	return {
 		id: data,
 		name: ['John', 'Jim', 'Bob', 'Susan', 'Sally', 'Delilah'][data - 1],
@@ -12,7 +19,7 @@ export const mockData = [1, 2, 3, 4, 5, 6].map((data) => {
 	};
 });
 
-export const mockColumns: Column<object>[] = [
+export const mockColumns: Column<MockTableData>[] = [
 	{
 		Header: 'Id',
 		accessor: 'id', // accessor is the "key" in the data
@@ -25,8 +32,8 @@ export const mockColumns: Column<object>[] = [
 	{
 		Header: 'Created at',
 		accessor: 'created_at',
-		Cell: ({ cell }) => {
-			return new Date(cell.value as number).toLocaleDateString();
+		Cell: ({ cell }: CellProps<MockTableData, MockTableData['created_at']>) => {
+			return new Date(cell.value).toLocaleDateString();
 		},
 	},
 	{


### PR DESCRIPTION
* Fix type hinting for Table `options` prop
* Re-export types from react-table so we don't have to install types separately