### PR TITLE
feat(dropdown): allow dropdown to be used without managing isOpen state

### DIFF
--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -40,6 +40,12 @@ const Template: ComponentStory<typeof Dropdown> = (args) => (
 	</DropdownStoryComponent>
 );
 
+const TemplateUncontrolled: ComponentStory<typeof Dropdown> = (args) => (
+	<Dropdown {...args}>
+		<MenuContent menuItems={menuItems} />
+	</Dropdown>
+);
+
 const TemplateWithIcons: ComponentStory<typeof Dropdown> = (args) => (
 	<div style={{ paddingTop: '200px' }}>
 		<DropdownStoryComponent>
@@ -54,6 +60,11 @@ export const Default = Template.bind({});
 Default.args = {
 	label: 'Show Options',
 	isOpen: false,
+};
+
+export const Uncontrolled = TemplateUncontrolled.bind({});
+Uncontrolled.args = {
+	label: 'Show Options',
 };
 
 export const FitMenuContent = Template.bind({});

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -26,6 +26,7 @@ const Dropdown: FC<DropdownProps> = ({
 	icon,
 	iconOpen,
 	iconClosed,
+	// Do not pass the isOpen attribute to let the component handle its own open/closed state
 	isOpen,
 	label = '',
 	flyoutClassName,
@@ -46,6 +47,7 @@ const Dropdown: FC<DropdownProps> = ({
 }) => {
 	const [referenceElement, setReferenceElement] = useState<HTMLElement | null>(null);
 	const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
+	const [isOpenInternal, setIsOpenInternal] = useState<boolean>(false);
 
 	const dropdownButtonSlot = useSlot(DropdownButton, children);
 	const dropdownContentSlot = useSlot(DropdownContent, children);
@@ -54,14 +56,22 @@ const Dropdown: FC<DropdownProps> = ({
 		placement,
 	});
 
+	const isOpenCombined = typeof isOpen === 'undefined' ? isOpenInternal : isOpen;
+
 	const bem = bemCls.bind(root);
 	const rootCls = clsx(className, triggerClassName, root, getVariantClasses(root, variants), {
 		[bem('trigger')]: triggerWidth === 'fit-content',
 	});
 
-	const toggle = (openState = !isOpen) => {
-		if (openState !== isOpen) {
-			openState ? onOpen() : onClose();
+	const toggle = (openState: boolean) => {
+		if (typeof isOpen === 'undefined') {
+			// Handle is open state internally
+			setIsOpenInternal(openState);
+		} else {
+			// Open state is handled by the parent component
+			if (openState !== isOpen) {
+				openState ? onOpen() : onClose();
+			}
 		}
 	};
 
@@ -77,7 +87,7 @@ const Dropdown: FC<DropdownProps> = ({
 				// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 				<div
 					className={rootCls}
-					onClick={() => toggle()}
+					onClick={() => toggle(!isOpenCombined)}
 					onKeyUp={() => null}
 					ref={setReferenceElement}
 				>
@@ -85,7 +95,7 @@ const Dropdown: FC<DropdownProps> = ({
 						<Button
 							iconStart={icon}
 							label={label}
-							iconEnd={isOpen ? iconOpen : iconClosed}
+							iconEnd={isOpenCombined ? iconOpen : iconClosed}
 						/>
 					)}
 				</div>
@@ -99,13 +109,13 @@ const Dropdown: FC<DropdownProps> = ({
 				{...attributes.popper}
 				className={clsx(
 					flyoutClassName,
-					isOpen ? 'c-dropdown__content-open' : 'c-dropdown__content-closed'
+					isOpenCombined ? 'c-dropdown__content-open' : 'c-dropdown__content-closed'
 				)}
 			>
 				<Menu
 					className={menuClassName}
 					rootClassName={menuRootClassName}
-					isOpen={isOpen}
+					isOpen={isOpenCombined}
 					search={searchMenu}
 				>
 					{dropdownContentSlot || children}

--- a/src/components/Dropdown/Dropdown.types.ts
+++ b/src/components/Dropdown/Dropdown.types.ts
@@ -8,7 +8,7 @@ export interface DropdownProps extends DefaultComponentProps {
 	icon?: ReactNode;
 	iconOpen?: ReactNode;
 	iconClosed?: ReactNode;
-	isOpen: boolean;
+	isOpen?: boolean;
 	label?: string;
 	flyoutClassName?: string;
 	menuClassName?: string;


### PR DESCRIPTION
Usually it is rare that we need to open a dropdown component without clicking on the trigger button.
This PR allows the isOpen attribute to be optional.

When you do not pass it (undefined) the component will manage its own open/closed state.
This makes it a lot easier to use since the parent component does not need to keep track of the isOpen state.

The old behavior still works, just pass a boolean to the isOpen attribute and the dropdown will behave as a controlled component.