### PR TITLE
fix(arc-557): avoid extra focussable element on textinput wrapper

### DIFF
--- a/src/components/TextInput/TextInput.stories.tsx
+++ b/src/components/TextInput/TextInput.stories.tsx
@@ -10,5 +10,15 @@ export default {
 
 const Template: ComponentStory<typeof TextInput> = (args) => <TextInput {...args} />;
 
+const TabOrderTemplate: ComponentStory<typeof TextInput> = (args) => (
+	<>
+		<TextInput {...args} />
+		<TextInput {...args} />
+	</>
+);
+
 export const Default = Template.bind({});
 Default.args = {};
+
+export const TabOrder = TabOrderTemplate.bind({});
+TabOrder.args = {};

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -13,7 +13,6 @@ export const TextInputDefaults = {
 	type: 'text',
 	value: '',
 	onChange: () => null,
-	onContainerKeyUp: () => null,
 };
 
 const TextInput: FC<TextInputProps> = forwardRef<HTMLInputElement, TextInputProps>(
@@ -29,7 +28,7 @@ const TextInput: FC<TextInputProps> = forwardRef<HTMLInputElement, TextInputProp
 			value = TextInputDefaults.value,
 			onChange = TextInputDefaults.onChange,
 			onContainerClick,
-			onContainerKeyUp = TextInputDefaults.onContainerKeyUp,
+			onContainerKeyUp,
 			...inputProps
 		},
 		ref
@@ -58,13 +57,7 @@ const TextInput: FC<TextInputProps> = forwardRef<HTMLInputElement, TextInputProp
 		);
 
 		return (
-			<div
-				className={rootCls}
-				role={hasContainerEvents ? 'button' : undefined}
-				tabIndex={hasContainerEvents ? 0 : undefined}
-				onClick={onContainerClick}
-				onKeyUp={onContainerKeyUp}
-			>
+			<div className={rootCls}>
 				{iconStart && renderIcon(iconStart, 'start')}
 				<input
 					{...inputProps}
@@ -74,6 +67,10 @@ const TextInput: FC<TextInputProps> = forwardRef<HTMLInputElement, TextInputProp
 					type={type}
 					value={value}
 					onChange={onChange}
+					role={hasContainerEvents ? 'button' : undefined}
+					tabIndex={hasContainerEvents ? 0 : undefined}
+					onClick={onContainerClick}
+					onKeyUp={onContainerKeyUp}
 				/>
 				{iconEnd && renderIcon(iconEnd, 'end')}
 			</div>


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/1710840/164646908-51c12b07-b5ae-456f-b081-5ed84dde6be3.png)

after:
![image](https://user-images.githubusercontent.com/1710840/164646917-277bcae2-16e2-42be-b474-f6a6bb687923.png)
