### PR TITLE
feat(table): expose getRowId on table options

### DIFF
--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -21,6 +21,7 @@ Default.args = {
 		// .bind() doesn't play well with generics so we have to cast our value
 		columns: mockColumns as Column<TableData>[],
 		data: mockData,
+		getRowId: (row) => row.id,
 	},
 	sortingIcons: {
 		...defaultSortingIcons,

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -13,6 +13,7 @@ const Table = <D extends TableData>({
 	getColumnProps = defaultPropGetter,
 	getHeaderProps = defaultPropGetter,
 	getRowProps = defaultPropGetter,
+	getRowId,
 	onRowClick,
 	onSortChange,
 	options,
@@ -34,8 +35,15 @@ const Table = <D extends TableData>({
 	const data = useMemo(() => options.data, [options.data]);
 	const columns = useMemo(() => options.columns, [options.columns]);
 
-	const instance = useTable(
-		{ ...options, manualSortBy: true, disableMultiSort: true, columns, data },
+	const instance = useTable<D>(
+		{
+			...options,
+			manualSortBy: true,
+			disableMultiSort: true,
+			columns,
+			data,
+			getRowId: getRowId as any,
+		},
 		useSortBy,
 		usePagination
 	);
@@ -60,7 +68,9 @@ const Table = <D extends TableData>({
 	// Render
 
 	const renderSortingIndicator = (column: HeaderGroup<D>) => {
-		if (!column.canSort || column.disableSortBy) return null;
+		if (!column.canSort || column.disableSortBy) {
+			return null;
+		}
 
 		if (column.isSorted) {
 			return column.isSortedDesc ? sortingIcons.desc : sortingIcons.asc;

--- a/src/components/Table/Table.types.ts
+++ b/src/components/Table/Table.types.ts
@@ -29,6 +29,7 @@ export interface TableProps<T extends TableData> extends DefaultComponentProps {
 	) => Partial<TableHeaderProps> | Partial<TableCellProps>;
 	getHeaderProps?: (column: HeaderGroup<T>) => Partial<TableHeaderProps>;
 	getRowProps?: (row: Row<T>) => Partial<TableRowProps>;
+	getRowId?: (originalRow: Row<T>, relativeIndex: number, parent?: Row<T>) => string;
 	onRowClick?: (event: MouseEvent<HTMLTableRowElement>, row: Row<T>) => void;
 	onSortChange?: (rules: SortingRule<T>[]) => void;
 	options: TableOptions<T>;


### PR DESCRIPTION
since the default id computation sometimes doesn't seem to be unique causing ghost columns to remain in the table