### PR TITLE
feat(arc-488): improve waveform shape, remove waveform-data dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,8 +65,7 @@
     "react-modal": "3.14.4",
     "react-popper": "2.2.5",
     "react-select": "5.2.1",
-    "react-table": "7.7.0",
-    "waveform-data": "4.3.0"
+    "react-table": "7.7.0"
   },
   "devDependencies": {
     "@commitlint/cli": "15.0.0",

--- a/src/components/FlowPlayer/FlowPlayer.stories.tsx
+++ b/src/components/FlowPlayer/FlowPlayer.stories.tsx
@@ -93,7 +93,7 @@ Audio.args = {
 		},
 	],
 	poster: undefined,
-	peakJson: peakJson,
+	waveformData: peakJson.data,
 };
 
 export const Playlist = Template.bind({});

--- a/src/components/FlowPlayer/FlowPlayer.tsx
+++ b/src/components/FlowPlayer/FlowPlayer.tsx
@@ -12,7 +12,6 @@
  *   <script src="/flowplayer/plugins/audio.min.js"></script>
  */
 import React, { createRef } from 'react';
-import WaveformData from 'waveform-data';
 
 import { FlowplayerInstance, FlowPlayerProps, FlowPlayerState } from './FlowPlayer.types';
 import { convertGAEventsArrayToObject } from './FlowPlayer.utils';
@@ -31,7 +30,6 @@ class FlowPlayer extends React.Component<FlowPlayerProps, FlowPlayerState> {
 		this.state = {
 			flowPlayerInstance: null,
 			startedPlaying: false,
-			waveformData: this.props.peakJson ? WaveformData.create(this.props.peakJson) : null,
 		};
 	}
 
@@ -204,16 +202,8 @@ class FlowPlayer extends React.Component<FlowPlayerProps, FlowPlayerState> {
 	}
 
 	private redrawPeaks(currentTime: number, duration: number) {
-		let waveformData = this.state.waveformData;
-		if (!waveformData) {
-			waveformData = this.props.peakJson ? WaveformData.create(this.props.peakJson) : null;
-			this.setState((state) => ({
-				...state,
-				waveformData,
-			}));
-		}
-		if (this.props.peakJson && this.peakCanvas.current && waveformData && duration) {
-			drawPeak(this.peakCanvas.current, waveformData, currentTime / duration);
+		if (this.props.peakJson && this.peakCanvas.current && duration) {
+			drawPeak(this.peakCanvas.current, this.props.peakJson.data, currentTime / duration);
 		}
 	}
 

--- a/src/components/FlowPlayer/FlowPlayer.tsx
+++ b/src/components/FlowPlayer/FlowPlayer.tsx
@@ -98,8 +98,8 @@ class FlowPlayer extends React.Component<FlowPlayerProps, FlowPlayerState> {
 		}
 
 		if (
-			(!!nextProps.peakJson && !this.props.peakJson) ||
-			(!nextProps.peakJson && !!this.props.peakJson)
+			(!!nextProps.waveformData && !this.props.waveformData) ||
+			(!nextProps.waveformData && !!this.props.waveformData)
 		) {
 			return true;
 		}
@@ -202,8 +202,12 @@ class FlowPlayer extends React.Component<FlowPlayerProps, FlowPlayerState> {
 	}
 
 	private redrawPeaks(currentTime: number, duration: number) {
-		if (this.props.peakJson && this.peakCanvas.current && duration) {
-			drawPeak(this.peakCanvas.current, this.props.peakJson.data, currentTime / duration);
+		if (this.props.waveformData && this.peakCanvas.current && duration) {
+			drawPeak(
+				this.peakCanvas.current,
+				this.props.waveformData || [],
+				currentTime / duration
+			);
 		}
 	}
 
@@ -373,7 +377,7 @@ class FlowPlayer extends React.Component<FlowPlayerProps, FlowPlayerState> {
 			flowPlayerInstance: flowplayerInstance,
 		});
 
-		if (this.props.peakJson) {
+		if (this.props.waveformData) {
 			this.redrawPeaks(0, 0);
 		}
 	}
@@ -381,7 +385,7 @@ class FlowPlayer extends React.Component<FlowPlayerProps, FlowPlayerState> {
 	render() {
 		return (
 			<div className={this.props.className + ' c-video-player'}>
-				{this.props.peakJson && (
+				{this.props.waveformData && (
 					<canvas ref={this.peakCanvas} className="c-peak" width="1212" height="779" />
 				)}
 				<div

--- a/src/components/FlowPlayer/FlowPlayer.types.ts
+++ b/src/components/FlowPlayer/FlowPlayer.types.ts
@@ -1,5 +1,5 @@
 import { ReactElement } from 'react';
-import { JsonWaveformData, WaveformData } from 'waveform-data';
+import { JsonWaveformData } from 'waveform-data';
 
 import { DefaultComponentProps } from '../../types';
 
@@ -85,5 +85,4 @@ export interface FlowPlayerProps extends DefaultComponentProps {
 export interface FlowPlayerState {
 	flowPlayerInstance: FlowplayerInstance | null;
 	startedPlaying: boolean;
-	waveformData: WaveformData | null;
 }

--- a/src/components/FlowPlayer/FlowPlayer.types.ts
+++ b/src/components/FlowPlayer/FlowPlayer.types.ts
@@ -1,5 +1,4 @@
 import { ReactElement } from 'react';
-import { JsonWaveformData } from 'waveform-data';
 
 import { DefaultComponentProps } from '../../types';
 
@@ -76,7 +75,7 @@ export interface FlowPlayerProps extends DefaultComponentProps {
 	canPlay?: boolean; // Indicates if the video can play at this type. Eg: will be set to false if a modal is open in front of the video player
 	className?: string;
 	customControls?: ReactElement;
-	peakJson?: JsonWaveformData;
+	waveformData?: number[];
 	googleAnalyticsId?: string;
 	googleAnalyticsEvents?: GoogleAnalyticsEvent[];
 	googleAnalyticsTitle?: string;

--- a/src/components/FlowPlayer/Peak/draw-peak.ts
+++ b/src/components/FlowPlayer/Peak/draw-peak.ts
@@ -1,13 +1,3 @@
-export interface JsonWaveformData {
-	version: number;
-	channels: number;
-	sample_rate: number;
-	samples_per_pixel: number;
-	bits: number;
-	length: number;
-	data: Array<number>;
-}
-
 function add(accumulator: number, a: number) {
 	return accumulator + a;
 }

--- a/src/components/FlowPlayer/Peak/draw-peak.ts
+++ b/src/components/FlowPlayer/Peak/draw-peak.ts
@@ -1,8 +1,28 @@
-import { WaveformData } from 'waveform-data';
+export interface JsonWaveformData {
+	version: number;
+	channels: number;
+	sample_rate: number;
+	samples_per_pixel: number;
+	bits: number;
+	length: number;
+	data: Array<number>;
+}
+
+function add(accumulator: number, a: number) {
+	return accumulator + a;
+}
+
+function sum(nums: number[]): number {
+	return nums.reduce(add, 0); // with initial value to avoid when the array is empty
+}
+
+function average(nums: number[]) {
+	return sum(nums) / nums.length;
+}
 
 export function drawPeak(
 	canvas: HTMLCanvasElement,
-	waveformData: WaveformData,
+	waveformData: number[],
 	percentagePlayed: number
 ) {
 	const ctx = canvas.getContext('2d');
@@ -15,26 +35,33 @@ export function drawPeak(
 	const barWidth = canvas.width / 100 / 2;
 
 	// Convert the waveform amplitude to bar height
-	const scaleY = (amplitude: number, height: number) => {
-		const range = 128;
-		const offset = 64;
-
-		return height - ((amplitude + offset) * height) / range;
+	const scaleY = (amplitude: number, canvasHeight: number, minVal: number, maxVal: number) => {
+		return ((amplitude - minVal + 0.1) / maxVal / 2) * canvasHeight;
 	};
 
 	// Reset the canvas
 	ctx.fillStyle = '#FFFFFF';
 	ctx.fillRect(0, 0, canvas.width || 0, canvas.height || 0);
 
-	const channel = waveformData.channel(0);
 	const half = (canvas.height || 0) / 2;
 
 	const waveFormLength = waveformData.length;
 
 	// Draw the peak bars
+	const values = [];
 	for (let barIndex = 0; barIndex < numOfBars; barIndex++) {
-		const val = channel.max_sample((waveFormLength / numOfBars) * barIndex);
-		const h = scaleY(val, half);
+		const rawDataSegment = waveformData.slice(
+			(waveFormLength / numOfBars) * barIndex,
+			((barIndex + 1) / numOfBars) * waveFormLength
+		);
+		const val = average(rawDataSegment);
+		values.push(val);
+	}
+
+	const minVal = Math.min(...values);
+	const maxVal = Math.max(...values);
+	for (let barIndex = 0; barIndex < numOfBars; barIndex++) {
+		const h = scaleY(values[barIndex], half, minVal, maxVal);
 
 		// Change color for already played audio
 		const percentageDrawn = barIndex / numOfBars;


### PR DESCRIPTION
before: using max values for each of the 100 intervals using waveform-data package.
![image](https://user-images.githubusercontent.com/1710840/166824400-6729f16d-5d7e-4415-91c3-99c9f14ccb87.png)


after: using manually calculated average values and scales between min and max average from 100 samples
![image](https://user-images.githubusercontent.com/1710840/166824543-2783c3aa-e3c1-493f-8176-57117b60b968.png)
