### PR TITLE
fix(avo-2466): Fix subtitles size on fullscreen videos

### DIFF
--- a/src/components/FlowPlayer/FlowPlayer.scss
+++ b/src/components/FlowPlayer/FlowPlayer.scss
@@ -77,10 +77,7 @@ $fp-controls-header-width-mobile: 50px;
 		position: absolute;
 		top: 50%;
 		left: 50%;
-		transform: translate(
-			-(math.div($player-play-button-dimensions, 2)),
-			-(math.div($player-play-button-dimensions, 2))
-		);
+		transform: translate(-(math.div($player-play-button-dimensions, 2)), -(math.div($player-play-button-dimensions, 2)));
 		background-image: url("data:image/svg+xml,%3Csvg fill='none' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5 21.9999C4.835 21.9999 4.67 21.9589 4.521 21.8779C4.2 21.7019 4 21.3659 4 20.9999V2.99989C4 2.63389 4.2 2.29689 4.521 2.12189C4.841 1.94689 5.232 1.95989 5.541 2.15889L19.541 11.1589C19.827 11.3429 20 11.6599 20 11.9999C20 12.3399 19.827 12.6569 19.541 12.8409L5.541 21.8409C5.376 21.9459 5.188 21.9999 5 21.9999ZM6 4.83189V19.1679L17.15 11.9999L6 4.83189Z' fill='white' fill-opacity='0.67'/%3E%3C/svg%3E%0A");
 		background-size: $player-play-button-icon-dimensions;
 		background-position: 55% center;
@@ -375,6 +372,12 @@ $fp-controls-header-width-mobile: 50px;
 
 			.fp-fullscreen-exit {
 				display: block;
+			}
+		}
+
+		@media (min-width: $g-bp2) {
+			.fp-captions {
+				font-size: 43px;
 			}
 		}
 	}


### PR DESCRIPTION
[AVO-2466](https://meemoo.atlassian.net/browse/AVO-2466)

Fix: Add css media query in order to size up the font on full screen

Before:
<img width="962" alt="image" src="https://user-images.githubusercontent.com/113341869/236201248-3b10b762-8fcb-4bb7-be6f-9ec0578c7f62.png">

After:
<img width="1920" alt="image" src="https://user-images.githubusercontent.com/113341869/236200777-98db2e11-485c-4264-bfad-a028a3c8bdd3.png">


[AVO-2466]: https://meemoo.atlassian.net/browse/AVO-2466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ