### PR TITLE
fix(arc-1661): add tooltip to button component

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -2,6 +2,7 @@ import clsx from 'clsx';
 import React, { FC, forwardRef, MouseEvent, ReactNode } from 'react';
 
 import { bemCls, getVariantClasses } from '../../utils';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../Tooltip';
 
 import { ButtonProps } from './Button.types';
 
@@ -18,6 +19,7 @@ const Button: FC<ButtonProps> = forwardRef<HTMLButtonElement, ButtonProps>(
 			label,
 			rootClassName: root = 'c-button',
 			title,
+			toolTipText,
 			type = 'button',
 			variants,
 			onClick,
@@ -47,7 +49,18 @@ const Button: FC<ButtonProps> = forwardRef<HTMLButtonElement, ButtonProps>(
 			</span>
 		);
 
-		return (
+		const wrapInTooltip = (element: JSX.Element): JSX.Element => {
+			return (
+				<Tooltip position="top">
+					<TooltipTrigger>{element}</TooltipTrigger>
+					<TooltipContent>
+						<span>{toolTipText}</span>
+					</TooltipContent>
+				</Tooltip>
+			);
+		};
+
+		const element = (
 			<button
 				{...htmlButtonProps}
 				className={rootCls}
@@ -71,6 +84,8 @@ const Button: FC<ButtonProps> = forwardRef<HTMLButtonElement, ButtonProps>(
 				</div>
 			</button>
 		);
+
+		return toolTipText ? wrapInTooltip(element) : element;
 	}
 );
 

--- a/src/components/Button/Button.types.ts
+++ b/src/components/Button/Button.types.ts
@@ -14,4 +14,5 @@ export interface ButtonProps
 	iconEnd?: ReactNode;
 	label?: string | ReactNode;
 	buttonRef?: RefObject<HTMLButtonElement>;
+	toolTipText?: string;
 }


### PR DESCRIPTION
<img width="1157" alt="image" src="https://github.com/viaacode/react-components/assets/113892598/c36ef0f0-516d-409b-a2cf-1ee3699ed53e">

Ticket: https://meemoo.atlassian.net/browse/ARC-1661
Client PR: https://github.com/viaacode/hetarchief-client/pull/903