### PR TITLE
fix(AVO-3140): put flowplayer annotation always below video

### DIFF
--- a/src/components/FlowPlayer/FlowPlayer.scss
+++ b/src/components/FlowPlayer/FlowPlayer.scss
@@ -24,10 +24,6 @@ $fp-controls-header-width-mobile: 50px;
 	flex-direction: column;
 	position: relative;
 
-	@media (min-width: $g-bp2) {
-		flex-direction: row;
-	}
-
 	.c-video-player__playlist__wrapper {
 		position: relative;
 		min-width: 30%;


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-3140

before:
![image](https://github.com/viaacode/react-components/assets/1710840/f7c54d46-dd6c-47f1-88f8-9eccf4ce1bc7)


after:
![image](https://github.com/viaacode/react-components/assets/1710840/21317103-1055-42b3-9537-d22a5d976a01)
