### PR TITLE
fix(ARC-3726): make tooltip clickable on mobile

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -12,6 +12,8 @@ import {
 	offset as floatingOffset,
 	type Placement,
 	safePolygon,
+	useClick,
+	useDismiss,
 	useFloating,
 	useFocus,
 	useHover,
@@ -59,7 +61,14 @@ const Tooltip: FunctionComponent<TooltipPropsSchema> = ({
 		}),
 	});
 	const focus = useFocus(context);
-	const { getFloatingProps, getReferenceProps } = useInteractions([hover, focus]);
+	const click = useClick(context);
+	const dismiss = useDismiss(context);
+	const { getFloatingProps, getReferenceProps } = useInteractions([
+		hover,
+		focus,
+		click,
+		dismiss,
+	]);
 
 	return tooltipSlot && triggerSlot ? (
 		<>


### PR DESCRIPTION
Deze PR heeft [deze PR](https://github.com/viaacode/hetarchief-client/pull/1570) nodig om te werken, want tooltips waren hidden op mobile

https://github.com/user-attachments/assets/35181076-ccc9-4625-9f20-1492c41d5a81

