### PR TITLE
fix(AVO-4053): fix lazy loading of rich text editor

### DIFF
--- a/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/src/components/RichTextEditor/RichTextEditor.tsx
@@ -18,7 +18,9 @@ const RichTextEditor: FunctionComponent<RichTextEditorProps> = (props) => {
 	useEffect(() => {
 		// Do not load the rich text editor during server side rendering
 		// Since it causes ESM/CommonJS issues with braft-editor and doesn't add much to the server side rendering anyway
-		if (isServerSideRendering()) return;
+		if (isServerSideRendering()) {
+			return;
+		}
 
 		let isMounted = true;
 		import('./RichTextEditorInternal.js').then((module) => {
@@ -38,7 +40,9 @@ const RichTextEditor: FunctionComponent<RichTextEditorProps> = (props) => {
 		</Flex>
 	);
 
-	if (!RichTextEditorInternal) return renderSpinner();
+	if (!RichTextEditorInternal) {
+		return renderSpinner();
+	}
 	return <RichTextEditorInternal {...props} />;
 };
 

--- a/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/src/components/RichTextEditor/RichTextEditor.tsx
@@ -1,26 +1,35 @@
-import { type FC, type FunctionComponent, lazy, Suspense, useEffect, useState } from 'react';
+import { type FC, type FunctionComponent, useEffect, useState } from 'react';
 import { isServerSideRendering } from '../../utils/is-server-side-rendering';
 import { Flex } from '../Flex/Flex';
 import type { RichTextEditorProps } from './RichTextEditor.types';
 
 /**
- * @deprecated Use RichTextEditorInternalWithInternalState instead since the full editor state isn't exposed, which should be more performant
- */
-let RichTextEditorInternal: FC<RichTextEditorProps> | null = null;
-if (!isServerSideRendering()) {
-	// Do not load the rich text editor during server side rendering
-	// Since it causes ESM/CcommonJS issues with braft-editor and doesn't add much to the server side rendering anyway
-	RichTextEditorInternal = lazy(() => import('./RichTextEditorInternal.js'));
-}
-
-/**
  * @deprecated Use RichTextEditorWithInternalState instead since the full editor state isn't exposed, which should be more performant
+ *
+ * The braft-based editor is loaded with a manual dynamic import (instead of React.lazy + Suspense)
+ * so that it is only rendered once the chunk is fully resolved. Rendering a Suspense boundary that
+ * suspends as a direct result of a discrete user interaction (e.g. clicking inside the editor)
+ * triggers React error #426 ("A component suspended while responding to synchronous input").
  */
 const RichTextEditor: FunctionComponent<RichTextEditorProps> = (props) => {
-	const [mounted, setMounted] = useState(false);
+	const [RichTextEditorInternal, setRichTextEditorInternal] =
+		useState<FC<RichTextEditorProps> | null>(null);
 
 	useEffect(() => {
-		setMounted(true);
+		// Do not load the rich text editor during server side rendering
+		// Since it causes ESM/CommonJS issues with braft-editor and doesn't add much to the server side rendering anyway
+		if (isServerSideRendering()) return;
+
+		let isMounted = true;
+		import('./RichTextEditorInternal.js').then((module) => {
+			if (isMounted) {
+				setRichTextEditorInternal(() => module.default);
+			}
+		});
+
+		return () => {
+			isMounted = false;
+		};
 	}, []);
 
 	const renderSpinner = () => (
@@ -29,12 +38,8 @@ const RichTextEditor: FunctionComponent<RichTextEditorProps> = (props) => {
 		</Flex>
 	);
 
-	if (!mounted) return renderSpinner();
-	return (
-		<Suspense fallback={renderSpinner()}>
-			{RichTextEditorInternal && <RichTextEditorInternal {...props} />}
-		</Suspense>
-	);
+	if (!RichTextEditorInternal) return renderSpinner();
+	return <RichTextEditorInternal {...props} />;
 };
 
 export default RichTextEditor;

--- a/src/components/RichTextEditor/RichTextEditorWithInternalState.tsx
+++ b/src/components/RichTextEditor/RichTextEditorWithInternalState.tsx
@@ -1,24 +1,35 @@
-import { type FC, type FunctionComponent, lazy, Suspense, useEffect, useState } from 'react';
+import { type FC, type FunctionComponent, useEffect, useState } from 'react';
 import { isServerSideRendering } from '../../utils/is-server-side-rendering';
 import { Flex } from '../Flex/Flex';
 import type { RichTextEditorWithInternalStateProps } from './RichTextEditor.types';
 
-let RichTextEditorInternalWithInternalState: FC<RichTextEditorWithInternalStateProps> | null = null;
-if (!isServerSideRendering()) {
-	// Do not load the rich text editor during server side rendering
-	// Since it causes ESM/CcommonJS issues with braft-editor and doesn't add much to the server side rendering anyway
-	RichTextEditorInternalWithInternalState = lazy(
-		() => import('./RichTextEditorInternalWithInternalState.js')
-	);
-}
-
+/**
+ * The braft-based editor is loaded with a manual dynamic import (instead of React.lazy + Suspense)
+ * so that it is only rendered once the chunk is fully resolved. Rendering a Suspense boundary that
+ * suspends as a direct result of a discrete user interaction (e.g. clicking inside the editor)
+ * triggers React error #426 ("A component suspended while responding to synchronous input").
+ */
 const RichTextEditorWithInternalState: FunctionComponent<RichTextEditorWithInternalStateProps> = (
 	props
 ) => {
-	const [mounted, setMounted] = useState(false);
+	const [RichTextEditorInternalWithInternalState, setRichTextEditorInternalWithInternalState] =
+		useState<FC<RichTextEditorWithInternalStateProps> | null>(null);
 
 	useEffect(() => {
-		setMounted(true);
+		// Do not load the rich text editor during server side rendering
+		// Since it causes ESM/CommonJS issues with braft-editor and doesn't add much to the server side rendering anyway
+		if (isServerSideRendering()) return;
+
+		let isMounted = true;
+		import('./RichTextEditorInternalWithInternalState.js').then((module) => {
+			if (isMounted) {
+				setRichTextEditorInternalWithInternalState(() => module.default);
+			}
+		});
+
+		return () => {
+			isMounted = false;
+		};
 	}, []);
 
 	const renderSpinner = () => (
@@ -27,14 +38,8 @@ const RichTextEditorWithInternalState: FunctionComponent<RichTextEditorWithInter
 		</Flex>
 	);
 
-	if (!mounted) return renderSpinner();
-	return (
-		<Suspense fallback={renderSpinner()}>
-			{!!RichTextEditorInternalWithInternalState && (
-				<RichTextEditorInternalWithInternalState {...props} />
-			)}
-		</Suspense>
-	);
+	if (!RichTextEditorInternalWithInternalState) return renderSpinner();
+	return <RichTextEditorInternalWithInternalState {...props} />;
 };
 
 export default RichTextEditorWithInternalState;


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-4053

AI:

What actually happens
[Error #426 = "a component suspended while responding to synchronous (discrete) input."](https://react.dev/errors/426) 

It fires when a click/keystroke triggers a render that hits a Suspense boundary whose child suspends synchronously, so React is forced to swap your editor for the "Laden..." fallback instead of doing it in a transition.

The flow in the content-edit page:

The editor (RICH_TEXT_EDITOR → RichTextEditorWithInternalStateWrapper → RichTextEditorWithInternalState) is rendered inside ContentBlockForm, which lives in the sidebar of ContentEditContentBlocks.tsx.
Clicking a block toggles activeBlockPosition (lines 130‑142), which switches the sidebar subtree between <DraggableList> and a plain <div> (lines 250‑275). That remounts the ContentBlockForm/editor subtree.
On that discrete click, the lazy chunk for RichTextEditorInternal* isn't guaranteed resolved → it suspends synchronously → #426, and the UI flashes the spinner.
The mounted-via-useEffect guard was meant to defer the lazy mount off the click, but it only protects the very first mount of each instance; a remount triggered directly by a click still suspends during discrete input.

The fix
Don't suspend during input — replace React.lazy + <Suspense> with a manual dynamic import() resolved in useEffect, storing the resolved component in state and rendering the spinner until it's ready. The braft editor is then only ever rendered when fully loaded, so a click can never trigger a suspend.