### PR TITLE
fix(rich-text-editor): keep the border visible in html view

### DIFF
--- a/src/components/RichTextEditor/RichTextEditor.scss
+++ b/src/components/RichTextEditor/RichTextEditor.scss
@@ -170,18 +170,18 @@ $button-color-active: #3498db;
 		}
 	}
 
+	.c-rich-text-editor__content--hidden {
+		display: none;
+	}
+
+	// Shares the .c-rich-text-editor__content class, so it keeps the same box,
+	// border and size as the WYSIWYG view it replaces.
 	.c-rich-text-editor__html-view {
-		position: absolute;
-		inset: 0;
-		top: 0;
+		display: block;
 		width: 100%;
-		height: 100%;
-		border: 0;
-		padding: 12px;
 		font-family: monospace;
 		font-size: 13px;
 		background: white;
-		z-index: 1;
 		resize: none;
 		outline: none;
 		box-sizing: border-box;

--- a/src/components/RichTextEditor/RichTextEditorInternal.tsx
+++ b/src/components/RichTextEditor/RichTextEditorInternal.tsx
@@ -12,7 +12,7 @@ import { EditorContent, useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import clsx from 'clsx';
 import type { ChangeEvent, FunctionComponent, ReactNode } from 'react';
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { RichTextEditorHeadingsDropdown } from './components/RichTextEditorHeadingsDropdown/RichTextEditorHeadingsDropdown';
 import { RichTextEditorLinkDropdown } from './components/RichTextEditorLinkDropdown/RichTextEditorLinkDropdown';
 import { RichTextEditorTableDropdown } from './components/RichTextEditorTableDropdown/RichTextEditorTableDropdown';
@@ -95,9 +95,7 @@ const RichTextEditorInternal: FunctionComponent<RichTextEditorInternalProps> = (
 	const [isHtmlView, setIsHtmlView] = useState(false);
 	const [isFullscreen, setIsFullscreen] = useState(false);
 	const [prettyHtml, setPrettyHtml] = useState(prettifyHtml(value || ''));
-	const [overlayTop, setOverlayTop] = useState(0);
 	const fileInputRef = useRef<HTMLInputElement | null>(null);
-	const toolbarRef = useRef<HTMLDivElement | null>(null);
 
 	const editor = useEditor({
 		extensions: [
@@ -162,26 +160,6 @@ const RichTextEditorInternal: FunctionComponent<RichTextEditorInternalProps> = (
 			editor.setEditable(!disabled);
 		}
 	}, [disabled, editor]);
-
-	useLayoutEffect(() => {
-		const updateOverlayTop = () => {
-			const toolbarHeight = toolbarRef.current?.getBoundingClientRect().height || 0;
-			setOverlayTop(toolbarHeight);
-		};
-
-		updateOverlayTop();
-
-		if (typeof ResizeObserver === 'undefined') {
-			return;
-		}
-
-		const observer = new ResizeObserver(updateOverlayTop);
-		if (toolbarRef.current) {
-			observer.observe(toolbarRef.current);
-		}
-
-		return () => observer.disconnect();
-	}, []);
 
 	const accept = useMemo(() => {
 		const accepts = Object.values(media?.accepts || {})
@@ -524,17 +502,18 @@ const RichTextEditorInternal: FunctionComponent<RichTextEditorInternalProps> = (
 			})}
 			id={id}
 		>
-			<div className={`${root}__toolbar`} ref={toolbarRef}>
+			<div className={`${root}__toolbar`}>
 				{resolvedControls.map((control, index) => renderControl(control, index))}
 			</div>
-			<EditorContent editor={editor} className={`${root}__content`} />
+			<EditorContent
+				editor={editor}
+				className={clsx(`${root}__content`, {
+					[`${root}__content--hidden`]: isHtmlView,
+				})}
+			/>
 			{isHtmlView && (
 				<textarea
-					className={`${root}__html-view`}
-					style={{
-						top: `${overlayTop}px`,
-						height: `calc(100% - ${overlayTop}px)`,
-					}}
+					className={clsx(`${root}__content`, `${root}__html-view`)}
 					value={prettyHtml}
 					onChange={(event) => setPrettyHtml(event.target.value)}
 					onBlur={handleHtmlBlur}


### PR DESCRIPTION
The HTML view renders in flow with the c-rich-text-editor__content class instead of as an absolutely positioned overlay, so it keeps the border and size of the view it replaces.